### PR TITLE
fix typos, add language specifier to code blocks

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,8 +7,8 @@ Cloud providers like AWS are extremely complex. Without prior DevOps expertise i
 
 So you are forced to choose between great developer experience and building a future-proof stack. **This is wrong.** Imagine if mobile developers needed one set of tools to _start_ building an app, and had to rebuild it with entirely different tools after a year or so – wouldn't that be ridiculous?
 
-
 ### Digger makes AWS simple
+
 It automatically generates infrastructure for your code in your AWS account.
 So you can build on AWS without having to deal with its complexity. See [How it works](./overview/how-it-works)
 
@@ -22,7 +22,7 @@ You can launch in minutes – no need to build from scratch, or even think of in
 
 ### You keep the full power of AWS
 
-Traditional PaaS like Heroku or Vercel run your code on their servers. Digger takes a different approach: it generates infrastructure-as-code (Terraform) that manages your AWS account. See [Digger vs Ohter](./overview/digger-vs-other)
+Traditional PaaS like Heroku or Vercel run your code on their servers. Digger takes a different approach: it generates infrastructure-as-code (Terraform) that manages your AWS account. See [Digger vs Other](./overview/digger-vs-other)
 
 This removes the main limitation of traditional PaaS. With Digger you can have great modern developer experience **and** get a future-proof stack at the same time. Terraform is industry standard for all things DevOps; with Digger you can customise every bit. You can even use your own bespoke templates with Digger. So unlike traditional PaaS, you never outgrow Digger.
 
@@ -32,8 +32,8 @@ Great question. Neither did Microsoft, nor did Google. We at Digger believe this
 
 AWS, GCP and Azure are essentially identical these days for the 95% of tasks at hand – but they don't want to make it easy for you to move to a different provider. So they lure you in with free credits, and then even if you aren't building anything unique you are unlikely to move – because you have invested lots of time in learning it.
 
-To be fair, AWS has introduced a number of easy-to-use tools. Beanstalk is the oldest one (their answer to Heroku); there's also Amplify, Copilot, Lightsail. But these tools suffer from the same problem as traditional PaaS: they severely limit your options. With Amplify you can only build static web apps (like Netlify); Copilot is exclusively for containers (like Google Cloud Run); Lightsail is essentially a simplified interface for a single EC2 instance (like Digital Ocean Droplet). See [Digger vs Ohter](./overview/digger-vs-other).
+To be fair, AWS has introduced a number of easy-to-use tools. Beanstalk is the oldest one (their answer to Heroku); there's also Amplify, Copilot, Lightsail. But these tools suffer from the same problem as traditional PaaS: they severely limit your options. With Amplify you can only build static web apps (like Netlify); Copilot is exclusively for containers (like Google Cloud Run); Lightsail is essentially a simplified interface for a single EC2 instance (like Digital Ocean Droplet). See [Digger vs Other](./overview/digger-vs-other).
 
 Major cloud providers today are strikingly similar to hardware manufacturers of 1970s. Each is making a collection of specialised "devices" – managed cloud services. Until recently they competed with each other by introducing new types of devices like specialised databases, serverless functions, container runtimes. But now the main types of devices are firmly established, with the possible exception of tools specific to machine learning. AWS, GCP and Azure today are one step away from becoming under-the-hood commodities – just like vendors of graphic cards, RAM and other standardised PC compoenents.
 
-For Amazon, Microsoft and Google introducing a simplification layer that is based on a cloud-agnostic open source tool (Terraform) would mean becoming commodities quicker. They don't want this. But it's inevitable, someone will do it eventually. So we thought we'd give it a shot. 
+For Amazon, Microsoft and Google introducing a simplification layer that is based on a cloud-agnostic open source tool (Terraform) would mean becoming commodities quicker. They don't want this. But it's inevitable, someone will do it eventually. So we thought we'd give it a shot.

--- a/docs/cli/django.md
+++ b/docs/cli/django.md
@@ -1,12 +1,14 @@
 # Deploy Django app with CLI
+
 This guide shows how to get a Django app running in your AWS account with Digger
-We are going to deploy this [TODO list application](https://github.com/diggerhq/django-todolist). This application needs a database for deployment. This specific application does not need celery and hence we don't need to create a queue or a sparate service for background workers.
+We are going to deploy this [TODO list application](https://github.com/diggerhq/django-todolist). This application needs a database for deployment. This specific application does not need celery and hence we don't need to create a queue or a separate service for background workers.
 
 You can see an example of this application deployed [here](https://todo-example.dggr.app/)
 
-![](https://i.imgur.com/lWZFxjn.png)
+![TODO list application](https://i.imgur.com/lWZFxjn.png)
 
 ### Prerequisites
+
 - Digger CLI installed - see [installation guide](/getting-started/installation.html)
 - Dockerfile - see the excellent [official guide](https://nodejs.org/en/docs/guides/nodejs-docker-webapp/) how to dockerize your Node.js app
 - [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed - we need to this to push your docker image!
@@ -15,21 +17,24 @@ You can see an example of this application deployed [here](https://todo-example.
 ### Clone the respository
 
 Clone our examples respository and remove the digger.yml file. We will re-initialize this file:
-```
+
+```bash
 git clone https://github.com/diggerhq/django-todolist
 cd django-todolist
 rm digger.yml
 ```
 
 ### Initialize a Digger project
+
 Create a new project in Digger and generate a `digger.yml` configuration file
-```
+
+```bash
 dg project init
 ```
 
 We can update the digger.yml file services section to the following:
 
-```
+```yaml
 services:
   backend:
     service_name: backend
@@ -46,7 +51,7 @@ services:
 
 Run the following command to sync these changes:
 
-```
+```bash
 dg sync
 ```
 
@@ -55,12 +60,14 @@ We could use dg service add to register the service, but in that case we need to
 :::
 
 ### Create an environment
+
 This will be the "destination" of your app in your AWS account. Any project has at least one environment, but often more: Production / Dev / Staging, or one per customer, or one per geography. We are passing a `--target` parameter which points to our [terraform template](https://github.com/diggerhq/target-fargate/tree/todolist). This template will create the infrastructure needed to deploy this app to Amazon ECS Fargate. We have customised it to include an RDS instance. It will also wire the right database settings as environment variables ;)
 
-```
+```bash
 dg env create production --target diggerhq/target-fargate@todolist
 dg env apply production
 ```
+
 Digger will generate the infrastructure in your AWS account, so this step may take a few minutes.
 
 You should see the URL pointing to your service's load balancer. By default this will not contain the node app but a default image that is deployed. To deploy the node application we need to create a release.
@@ -74,26 +81,25 @@ You may see 'Service Temporarily Unavailable' once you load the loadbalancer url
 :::
 
 ### Deploy your app
-```
+
+```bash
 dg env build production
 dg env push production
 dg env deploy production
 ```
-You should see the URL pointing to your service's load balancer. That's it! your todolist app deployed🙂
 
+You should see the URL pointing to your service's load balancer. That's it! your todolist app deployed🙂
 
 ### Note on environment variables
 
 Digger allows you to map important environment variables from your application directly into your application. In the above example, we automatically map the DATABASE_URL per environment into your application so that deployment just works out of the box. You can see a list of your environment variables in the [web UI](https://app.digger.dev/):
 
-![](https://i.imgur.com/MhLYXT3.png)
+![Digger Environment Web UI](https://i.imgur.com/MhLYXT3.png)
 
 ### Destroy the environment
+
 This will remove all infrastructure for the production environment from your AWS account if you don't need it anymore
-```
+
+```bash
 dg env destroy production
 ```
-
-
-
-

--- a/docs/cli/installation.md
+++ b/docs/cli/installation.md
@@ -1,15 +1,22 @@
 # Install Digger CLI
+
 The `dg` command-line tool is one of the two primary ways to interact with Digger. The other is the Web UI at [app.digger.dev](https://app.digger.dev)
+
 ## Homebrew
-```
+
+```bash
 brew install diggerhq/tap/dg
 ```
+
 ## NPM
-```
+
+```bash
 npm install -g diggercli
 ```
+
 ## Direct download
-```
+
+```bash
 # for linux
 VERSION=`curl https://digger-releases.s3-eu-west-1.amazonaws.com/STABLE-VERSION`
 curl -O https://digger-releases.s3-eu-west-1.amazonaws.com/linux/dg-linux-$VERSION.zip
@@ -17,7 +24,7 @@ unzip dg-linux-$VERSION.zip
 ln -s `pwd`/dg/dg /usr/local/bin/dg
 ```
 
-```
+```bash
 # for darwin (MAC OS)
 VERSION=`curl https://digger-releases.s3-eu-west-1.amazonaws.com/STABLE-VERSION`
 curl -O https://digger-releases.s3-eu-west-1.amazonaws.com/darwin/dg-darwin-$VERSION.zip
@@ -25,11 +32,12 @@ unzip dg-darwin-$VERSION.zip
 ln -s `pwd`/dg/dg /usr/local/bin/dg
 
 ```
+
 ## Using Docker
 
 You can quickly test dg using docker with our official image. The command bellow will launch a docker container in the current directory and map the volume to its folder.
 
-```
+```bash
 docker run -v ${PWD}:/code -it public.ecr.aws/g1x6q1x1/dg:latest sh
 
 dg --version
@@ -40,7 +48,7 @@ since dg command uses docker internally, you may need to map your host machine's
 :::
 
 ## Test that it works
-```
+
+```bash
 dg --version
 ```
-

--- a/docs/cli/node-express.md
+++ b/docs/cli/node-express.md
@@ -1,7 +1,9 @@
 # Deploy Node app with CLI
+
 This guide shows how to get a Node.js Express app running in your AWS account with Digger
 We are going to deploy this [sample application](https://github.com/diggerhq/digger-examples/tree/master/node-service) from the Digger Samples repository on GitHub.
 It is a Node.js Express application created with the official [Express Generator](https://expressjs.com/en/starter/generator.html), structured like this:
+
 ```
 ├── bin
 │   └── www
@@ -22,6 +24,7 @@ It is a Node.js Express application created with the official [Express Generator
 ```
 
 ### Prerequisites
+
 - Digger CLI installed - see [installation guide](/getting-started/installation.html)
 - Dockerfile - see the excellent [official guide](https://nodejs.org/en/docs/guides/nodejs-docker-webapp/) how to dockerize your Node.js app
 - [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed - we need to this to push your docker image!
@@ -30,38 +33,46 @@ It is a Node.js Express application created with the official [Express Generator
 ### Clone the respository
 
 Clone our examples respository:
-```
+
+```bash
 git clone https://github.com/diggerhq/digger-examples
 cd digger-examples
 ```
 
 ### Initialize a Digger project
+
 Create a new project in Digger and generate a `digger.yml` configuration file
-```
+
+```bash
 dg project init
 ```
 
 ### Register your service
+
 Digger will analyse your app's code, update the `digger.yml` file with appropriate settings, and synchronise it with the backend
-```
+
+```bash
 dg service add
 dg sync
 ```
+
 Alternatively you could just update this file manually, then run `dg sync`
 
 ### Create an environment
+
 This will be the "destination" of your app in your AWS account. Any project has at least one environment, but often more: Production / Dev / Staging, or one per customer, or one per geography. We are passing a `--target` parameter which points to our [terraform template](https://github.com/diggerhq/target-fargate/tree/v1.0.4). This template will create the infrastructure needed to deploy this app to Amazon ECS Fargate.
 
-```
+```bash
 dg env create production --target diggerhq/target-fargate@v1.0.4
 dg env apply production
 ```
+
 Digger will generate the infrastructure in your AWS account, so this step may take a few minutes.
 
 You should see the URL pointing to your service's load balancer. By default this will not contain the node app but a default image that is deployed. To deploy the node application we need to create a release.
 
 ::: tip
-To see which resources are aboout to be created you can run `dg env plan production`. In general it is recommended to run this command before each apply. You can see the apply happening live by passing the `--verbose` option to it.
+To see which resources are about to be created you can run `dg env plan production`. In general it is recommended to run this command before each apply. You can see the apply happening live by passing the `--verbose` option to it.
 :::
 
 ::: tip
@@ -69,21 +80,19 @@ You may see 'Service Temporarily Unavailable' once you load the loadbalancer url
 :::
 
 ### Deploy your app
-```
+
+```bash
 dg env build production
 dg env push production
 dg env deploy production
 ```
+
 You should see the URL pointing to your service's load balancer. That's it! 🙂
 
-
-
 ### Destroy an environment
+
 This will remove all infrastructure for the production environment from your AWS account if you don't need it anymore
-```
+
+```bash
 dg env destroy production
 ```
-
-
-
-

--- a/docs/customize/cicd.md
+++ b/docs/customize/cicd.md
@@ -4,69 +4,65 @@ You can use digger CLI within your CI/CD pipeline within your favourite tools su
 
 ## Github Actions
 
-In the snippet bellow we show an example of a github action which will release your service `svc1` on push. You can see a full GH workflow example in our [TODO example repository](https://github.com/diggerhq/django-todolist/blob/master/.github/workflows/deploy.yml)
+In the snippet bellow we show an example of a GitHub action which will release your service `svc1` on push. You can see a full GH workflow example in our [TODO example repository](https://github.com/diggerhq/django-todolist/blob/master/.github/workflows/deploy.yml)
 
-
-```
+```yaml
 name: Digger CI
 on:
   push:
     branches: [master]
-
 
   build-push-release:
     runs-on: ubuntu-16.04
     needs:
       - get_tag_version
     steps:
-    - name: Checkout
-      uses: actions/checkout@v1
+      - name: Checkout
+        uses: actions/checkout@v1
 
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: eu-west-1
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-1
 
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.8'
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
 
-    - name: Build and push and release
-      env:
-        DIGGER_TOKEN: ${{ secrets.DIGGER_TOKEN }}
-        DIGGER_AWS_KEY: ${{ secrets.DIGGER_AWS_KEY }}
-        DIGGER_AWS_SECRET: ${{ secrets.DIGGER_AWS_SECRET }}
-        BACKEND_ENDPOINT: "https://backend.digger.dev"
-        WEBAPP_ENDPOINT: "https://app.digger.dev"
-      run: |
-        export TAG_VERSION=${{needs.get_tag_version.outputs.tag_version}} 
+      - name: Build and push and release
+        env:
+          DIGGER_TOKEN: ${{ secrets.DIGGER_TOKEN }}
+          DIGGER_AWS_KEY: ${{ secrets.DIGGER_AWS_KEY }}
+          DIGGER_AWS_SECRET: ${{ secrets.DIGGER_AWS_SECRET }}
+          BACKEND_ENDPOINT: "https://backend.digger.dev"
+          WEBAPP_ENDPOINT: "https://app.digger.dev"
+        run: |
+          export TAG_VERSION=${{needs.get_tag_version.outputs.tag_version}}
 
-        # Install diggercli
-        pip install --upgrade git+https://github.com/diggerhq/cli@master
+          # Install diggercli
+          pip install --upgrade git+https://github.com/diggerhq/cli@master
 
-        echo "> Building docker image"
-        dg env build stage --service svc1
-        echo "> Pushing docker image to ECR"    
-        dg env push stage --service svc1 --aws-key "$DIGGER_AWS_KEY" --aws-secret "$DIGGER_AWS_SECRET"
-        echo "> Releasing"    
-        dg env push release --service svc1 --aws-key "$DIGGER_AWS_KEY" --aws-secret "$DIGGER_AWS_SECRET"
-
+          echo "> Building docker image"
+          dg env build stage --service svc1
+          echo "> Pushing docker image to ECR"
+          dg env push stage --service svc1 --aws-key "$DIGGER_AWS_KEY" --aws-secret "$DIGGER_AWS_SECRET"
+          echo "> Releasing"
+          dg env push release --service svc1 --aws-key "$DIGGER_AWS_KEY" --aws-secret "$DIGGER_AWS_SECRET"
 ```
 
-## Gitlab CI
+## GitLab CI
 
-In the snippet bellow we show an example of a gitlab ci. We are using the offical docker image of digger to run digger commands. This comes with all dg dependencies included in the image
+In the snippet bellow we show an example of a GitLab ci. We are using the official docker image of digger to run digger commands. This comes with all dg dependencies included in the image
 
-```
+```yaml
 default:
   image: public.ecr.aws/g1x6q1x1/dg:v0.2.17
 
-
 variables:
-  # You need to configure the following variables as gitlab secrets
+  # You need to configure the following variables as GitLab secrets
   # DIGGER_TOKEN: ${{DIGGER_TOKEN}}
   # DIGGER_AWS_KEY: ${{ secrets.DIGGER_AWS_KEY }}
   # DIGGER_AWS_SECRET: ${{ secrets.DIGGER_AWS_SECRET }}
@@ -79,7 +75,7 @@ variables:
   DOCKER_TLS_CERTDIR: "/certs"
   DOCKER_TLS_VERIFY: 1
   DOCKER_CERT_PATH: "$DOCKER_TLS_CERTDIR/client"
-  
+
 # This is needed to allow docker-in-docker
 services:
   - docker:19.03.12-dind
@@ -88,7 +84,7 @@ release-staging:
   stage: build
   variables:
     # This is the name of your environment
-    DG_ENV: "staging" 
+    DG_ENV: "staging"
   only:
     - develop
   script:
@@ -99,4 +95,3 @@ release-staging:
     - echo "> Releasing docker image"
     - dg env release "$DG_ENV" --service $SERVICE --tag $TAG_VERSION --aws-key "$DIGGER_AWS_KEY" --aws-secret "$DIGGER_AWS_SECRET"
 ```
-

--- a/docs/customize/terraform.md
+++ b/docs/customize/terraform.md
@@ -55,7 +55,7 @@ At the moment custom targets are only supported in the CLI but not in Web UI. Yo
 Template structure is subject to changing in future versions of digger
 :::
 
-Digger Targets are not much different from standard terraform. We use jinja2 under the hood to pass configuration parameters to these templates. The flow is summarised in the visual bellow. Options flow from the digger.yml, along with additional environment options, directly into a template store in a github repository. These are used to render terraform which can be applied in the user's account.
+Digger Targets are not much different from standard terraform. We use jinja2 under the hood to pass configuration parameters to these templates. The flow is summarised in the visual bellow. Options flow from the digger.yml, along with additional environment options, directly into a template store in a GitHub repository. These are used to render terraform which can be applied in the user's account.
 
 The directory structure of digger templates looks similar to terraform. We run the main files under the `main/` directory. You can see an example terraform template for fargate in this [example repository](https://github.com/diggerhq/target-fargate/tree/example)
 
@@ -74,11 +74,9 @@ Bellow the main components of a digger templates are explained:
 
 **main/**: The terraform apply command is run in this context and hence all the .tf files will be included in the generated infrastructure. Any file with the suffix "\*.template.tf" is rendered to a .tf file before the apply and therefore you can use standard jinja template tags {{}} in these files.
 
-
 **service.template.tf**: This is a special file that is rendered multiple times for each service entry in the digger.yml file. For example, if we have two services svc1 and svc2, we will end up with service-svc1.tf and service-svc2.tf. Each file will be able to use the service options as standard {{}} jinja templates.
 
 **module/**: you can use either local or remote modules as supported by terraform. For local modules you can have these as sister folders and refer to them directly.
-
 
 ### Using Terraform variables
 
@@ -96,7 +94,7 @@ Any output which starts `DGVAR_` prefix will be mapped to an environment variabl
 
 To integrate with Parameter store secrets, create an entry of the secret value and then output the value of it using `DGVAR_` prefix as mentioned above. Here is an example: [database password](https://github.com/diggerhq/target-fargate/blob/example/main/database.template.tf#L43) in parameter store mapped to [outputs](https://github.com/diggerhq/target-fargate/blob/example/main/outputs.template.tf#L40) using its arn value:
 
-```
+```bash
 resource "aws_ssm_parameter" "database_password" {
     name = "${var.app}.${var.environment}.rds.database_password"
     value = local.database_password
@@ -116,9 +114,9 @@ output "DGVAR_POSTGRES_PASSWORD" {
 
 Some resources such as S3 buckets have to be unique globally. In addition, we want to avoid having naming conflicts of resources such as ECS clusters.
 
-In Digger, project names are unique globally. Therefore if you want to gaurantee unique names of your resources across environments is to use project_name_environment_name patterns. With that said, many terraform resources also support a name_prefix attribute which gaurantee uniqueness. It is good to make use of this name_prefix attribute to avoid problems since in this case terraform will gaurantee a unique resource on your behalf:
+In Digger, project names are unique globally. Therefore if you want to guarantee unique names of your resources across environments is to use project_name_environment_name patterns. With that said, many terraform resources also support a name_prefix attribute which guarantee uniqueness. It is good to make use of this name_prefix attribute to avoid problems since in this case terraform will guarantee a unique resource on your behalf:
 
-```
+```bash
 resource "aws_s3_bucket" "b" {
   bucket_prefix = "my-dg-test-bucket"
   acl    = "private"

--- a/docs/getting-started/secrets.md
+++ b/docs/getting-started/secrets.md
@@ -1,6 +1,6 @@
 # Secrets
 
-Digger has a unique way of handling secrets by never storing them. We will integrate with yor cloud provider to store your secrets in your own account and then at every release we load the secret in your app. In this way Digger never sees your secrets and sensitive data.
+Digger has a unique way of handling secrets by never storing them. We will integrate with your cloud provider to store your secrets in your own account and then at every release we load the secret in your app. In this way Digger never sees your secrets and sensitive data.
 
 Let us look at the steps creating a secret in your AWS account using ParameterStore and integrating this in your service so that your application can read it.
 
@@ -11,7 +11,7 @@ First of all go to the parameterstore section by searching for it:
 Next step is to click on create parameter:
 
 ![Parameter Store](../img/parameterstore_view.png)
-    
+
 Fill in a name, Use a "SecureSecret" as a type and then fill in your sensitive value:
 
 ![Parameter Store](../img/parameterstore_new.png)

--- a/docs/misc/tagging-and-rollbacks.md
+++ b/docs/misc/tagging-and-rollbacks.md
@@ -1,24 +1,23 @@
 # Image tagging rollbacks
 
-While preparing your docker builds and releases its a good idea to tag your images. Digger uses a default tag of `:latest` but this means that to rollback to a previous version of your code you would need to rebuild that tag or branch. 
+While preparing your docker builds and releases its a good idea to tag your images. Digger uses a default tag of `:latest` but this means that to rollback to a previous version of your code you would need to rebuild that tag or branch.
 
 With the digger cli you can specify tags in the cli. you need to do that for your build-push-release cycles.
 
-```
+```bash
 dg env build --tag v1
 dg env push --tag v1
 dg env release --tag v1
 ```
 
-This way you can trigger a release for a previous version by passing the `v1` tag. You can also use the same tags for a CI/CD setting. For example, in a Github Action, you can trigger the action everytime a version tag is pushed:
+This way you can trigger a release for a previous version by passing the `v1` tag. You can also use the same tags for a CI/CD setting. For example, in a GitHub Action, you can trigger the action everytime a version tag is pushed:
 
-
-```
+```yaml
 name: Digger CI
 on:
   push:
     tags:
-      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+      - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
 
 jobs:
   get_tag_version:
@@ -27,52 +26,49 @@ jobs:
       tag_version: ${{ steps.get_tag.outputs.VERSION }}
       stage: ${{ steps.get_stage.outputs.STAGE }}
     steps:
-    - name: Set the tag version
-      id: get_tag
-      run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
-
+      - name: Set the tag version
+        id: get_tag
+        run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
 
   build-push-release:
     runs-on: ubuntu-16.04
     needs:
       - get_tag_version
     steps:
-    - name: Checkout
-      uses: actions/checkout@v1
+      - name: Checkout
+        uses: actions/checkout@v1
 
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: eu-west-1
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-1
 
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.8'
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
 
-    - name: Build and push and release
-      env:
-        DIGGER_TOKEN: ${{ secrets.DIGGER_TOKEN }}
-        DIGGER_AWS_KEY: ${{ secrets.DIGGER_AWS_KEY }}
-        DIGGER_AWS_SECRET: ${{ secrets.DIGGER_AWS_SECRET }}
-        BACKEND_ENDPOINT: "https://backend.digger.dev"
-        WEBAPP_ENDPOINT: "https://app.digger.dev"
-      run: |
-        export TAG_VERSION=${{needs.get_tag_version.outputs.tag_version}} 
+      - name: Build and push and release
+        env:
+          DIGGER_TOKEN: ${{ secrets.DIGGER_TOKEN }}
+          DIGGER_AWS_KEY: ${{ secrets.DIGGER_AWS_KEY }}
+          DIGGER_AWS_SECRET: ${{ secrets.DIGGER_AWS_SECRET }}
+          BACKEND_ENDPOINT: "https://backend.digger.dev"
+          WEBAPP_ENDPOINT: "https://app.digger.dev"
+        run: |
+          export TAG_VERSION=${{needs.get_tag_version.outputs.tag_version}}
 
-        # Install diggercli
-        pip install --upgrade git+https://github.com/diggerhq/cli@master
+          # Install diggercli
+          pip install --upgrade git+https://github.com/diggerhq/cli@master
 
-        echo "> Building docker image"
-        dg env build stage --service svc1 --tag $TAG_VERSION
-        echo "> Pushing docker image to ECR"    
-        dg env push stage --service svc1 --tag $TAG_VERSION --aws-key "$DIGGER_AWS_KEY" --aws-secret "$DIGGER_AWS_SECRET"
-        echo "> Releasing"    
-        dg env push release --service svc1 --tag $TAG_VERSION --aws-key "$DIGGER_AWS_KEY" --aws-secret "$DIGGER_AWS_SECRET"
-
-
+          echo "> Building docker image"
+          dg env build stage --service svc1 --tag $TAG_VERSION
+          echo "> Pushing docker image to ECR"
+          dg env push stage --service svc1 --tag $TAG_VERSION --aws-key "$DIGGER_AWS_KEY" --aws-secret "$DIGGER_AWS_SECRET"
+          echo "> Releasing"
+          dg env push release --service svc1 --tag $TAG_VERSION --aws-key "$DIGGER_AWS_KEY" --aws-secret "$DIGGER_AWS_SECRET"
 ```
 
 In the above snippet we listen for changes to changes in a tag push and use the same tag to build and push with `dg`. This means that to rollback a previous version one can re-run a previous workflow.

--- a/docs/overview/concepts.md
+++ b/docs/overview/concepts.md
@@ -3,9 +3,11 @@ sidebarDepth: 1
 ---
 
 # Concepts
+
 Digger introduces a simple yet powerful model that works well for large enterprise stacks, small SaaS products, and everything in between.
 
 ## Project
+
 A Project is a top-level entity in Digger, containing all others. Project roughly corresponds to an Organisation in GitHub. Project manages all parts of a single software product with all its apps, services, environments and configurations.
 
 ::: tip
@@ -13,7 +15,9 @@ Use one project for all related apps and services. If your apps and services dep
 :::
 
 ## Service
+
 Service are the basic building blocks of your stack. Any code that you'd want deployed somewhere is a Service. Services often map to repositories in GitHub, or to top-level folders in a monorepo configuration. Examples of Services:
+
 - A Django app
 - A Node.js microservice
 - A Lambda function
@@ -21,7 +25,9 @@ Service are the basic building blocks of your stack. Any code that you'd want de
 - A static website
 
 ## Resource
-Resources are supporting infrastructure componets that Services need. The key difference from Services is that they are not your application code - Resources are fully managed by your cloud provider. Examples of Resources:
+
+Resources are supporting infrastructure components that Services need. The key difference from Services is that they are not your application code - Resources are fully managed by your cloud provider. Examples of Resources:
+
 - A database
 - An S3 bucket
 - A Redis instance
@@ -32,12 +38,14 @@ If you choose to manage a database yourself in a Docker container for example, t
 :::
 
 ## Environment
+
 An Environment is the destination for services to be deployed into, with underlying AWS infrastructure managed by Digger. Every Environment has all of the services. Versions of each service do not necessarily match across environment unless you deploy the exact same versions everywhere.
 
 There always is at least one environment, but often more – a dev / staging / production setup is fairly typical. If you are building B2B SaaS software then you'd often want to have dedicated environments for every customer. Another common pattern is to have separate environments in every geography or jurisdiction, mainly for data regulatory compliance reasons.
 
 ## Environment Config
-Configuration specific to a particular environment. It stores parameters such as sizes of instances, whether or not some services and resorces are enabled in this environment, etc. If you are using CLI or have connected Infrastructure Repository then you can find Environment Config in the `digger.config.yml` file.
+
+Configuration specific to a particular environment. It stores parameters such as sizes of instances, whether or not some services and resources are enabled in this environment, etc. If you are using CLI or have connected Infrastructure Repository then you can find Environment Config in the `digger.config.yml` file.
 
 ## Target
 

--- a/docs/overview/digger-vs-other.md
+++ b/docs/overview/digger-vs-other.md
@@ -1,6 +1,7 @@
 ---
 sidebarDepth: 1
 ---
+
 # Digger vs Other
 
 Existing cloud platforms on the market today give you one of the two:
@@ -10,16 +11,16 @@ Existing cloud platforms on the market today give you one of the two:
 
 Digger gives you **both**, because under the hood it generates infrastructure-as-code (Terraform) and manages your cloud account through it.
 
-|                             | AWS / GCP / Azure       | Heroku & PaaS     | Firebase & BaaS | Digger + AWS
-| --------------------------- | ----------------------- | ----------------- |-----------------|--------------
-| Ease of use & DX            | -                       | ++                | ++++            | ++++
-| Power & flexibility         | ++++                    | -                 | --              | ++++
-| Cost                        | $                       | $$$$              | $$$$            | $
-
+|                     | AWS / GCP / Azure | Heroku & PaaS | Firebase & BaaS | Digger + AWS |
+| ------------------- | ----------------- | ------------- | --------------- | ------------ |
+| Ease of use & DX    | -                 | ++            | ++++            | ++++         |
+| Power & flexibility | ++++              | -             | --              | ++++         |
+| Cost                | $                 | $$$$          | $$$$            | $            |
 
 Digger is quick to start and easy to use, but you can also customise every bit whenever you need it because the full power of AWS is still accessible.
 
 ## Heroku and other platforms-as-a-service
+
 PaaS like Heroku or Digital Ocean App Platform run your code on their servers and provide you with an easy to use web interface to manage your application. They completely hide the infrastructure complexity from you. So you can start quickly and move fast using a PaaS. This is great.
 
 But platforms-as-a-service offer fewer services than big cloud providers and you don't have access to the lower infrastructure level. Teams tend to outgorw it quickly and have to migrate. PaaS also can be 2x - 5x more expensive than AWS, and do not give you as much free credits as big cloud providers.
@@ -28,7 +29,7 @@ Digger gives you the benefits of a PaaS without the downsides. It looks and feel
 
 ## Firebase and other backend-as-a-service platforms
 
-Tools like Firebase, Supabase or Nhost provide a set of drop-in components for your backend: database, serverless functions, storage, authentication. Unlike Heroku, you don't deploy your backend to Firebase – you configure it so it *is* your backend. That's easier and less maintenance than PaaS. It is also even more limiting.
+Tools like Firebase, Supabase or Nhost provide a set of drop-in components for your backend: database, serverless functions, storage, authentication. Unlike Heroku, you don't deploy your backend to Firebase – you configure it so it _is_ your backend. That's easier and less maintenance than PaaS. It is also even more limiting.
 
 Digger is more flexible. You can create functions and databases in Digger UI in just a few clicks, so it is just as easy. But under the hood the databases are RDS instances and functions are Lambdas, and you have access to their full configuration.
 
@@ -70,7 +71,7 @@ Kubernetes is the de-facto standard for container orchestration. Originally crea
 
 It is not correct to compare Digger with Kubernetes, because **Digger supports Kubernetes**. You can easily provision a Kubernetes cluster with Digger by simply using a different [Target](./understanding-targets). The default target in Digger is ECS Fargate because if you are just starting out then Kubernetes can be an overkill in terms of both complexity and cost.
 
-Container orchestration engine is just one part of your stack. Others include webapps, storage, databases, queues, caches, etc etc. Digger manages your _entire_ stack. You can use Kubernetes as your orchestration engine, or you can choose something else. All you need to do to switch orchestration engines in Digger is create a new environment and select a different target.
+Container orchestration engine is just one part of your stack. Others include webapps, storage, databases, queues, caches, etc. Digger manages your _entire_ stack. You can use Kubernetes as your orchestration engine, or you can choose something else. All you need to do to switch orchestration engines in Digger is create a new environment and select a different target.
 
 ## Serverless
 
@@ -82,21 +83,21 @@ This is a loaded term :)
 
 **Serverless.com** is a web UI of the Serverless Framework. Similarly to Digger, it manages your AWS account from its backend.
 
-----------
+---
 
 ### Digger vs Heroku feature comparison
 
-|                             | Digger + AWS            | Heroku            |
-| --------------------------- | ----------------------- | ----------------- |
-| Your code runs in           | Your AWS account        | Heroku servers    |
-| Control over infrastructure | Yes                     | No                |
-| Free credits                | up to $100k             | None              |
-| Compute with 1GB of RAM     | $7.6 per month          | $25 per month     |
-| Database with 8GB of RAM    | $99 per month           | $200 per month    |
-| Services provided           | 200+                    | ~10               |
-| Regions                     | 25                      | 6                 |
-| Compliance                  | Enterprise-grade        | Limited           |
-| Infrastructure-as-code      | Yes                     | No                |
-| Kubernetes                  | Yes                     | No                |
-| Serverless                  | Yes                     | No                |
-| Data stays in your cloud    | Yes                     | No                |
+|                             | Digger + AWS     | Heroku         |
+| --------------------------- | ---------------- | -------------- |
+| Your code runs in           | Your AWS account | Heroku servers |
+| Control over infrastructure | Yes              | No             |
+| Free credits                | up to $100k      | None           |
+| Compute with 1GB of RAM     | $7.6 per month   | $25 per month  |
+| Database with 8GB of RAM    | $99 per month    | $200 per month |
+| Services provided           | 200+             | ~10            |
+| Regions                     | 25               | 6              |
+| Compliance                  | Enterprise-grade | Limited        |
+| Infrastructure-as-code      | Yes              | No             |
+| Kubernetes                  | Yes              | No             |
+| Serverless                  | Yes              | No             |
+| Data stays in your cloud    | Yes              | No             |

--- a/docs/overview/how-it-works.md
+++ b/docs/overview/how-it-works.md
@@ -18,9 +18,9 @@ To address this, Digger introduces several new [Concepts](./concepts):
 
 - **Resources** (databases, object storage, queues, etc) - infrastructure dependencies required by Services. For example, "postgres 12 database".
 
-Services and Resources form the *logical* structure of your stack. We call it "infrastructure interface" - what your code needs from the infrastructure
+Services and Resources form the _logical_ structure of your stack. We call it "infrastructure interface" - what your code needs from the infrastructure
 
-- **Environments** - isolated independent copies of your entire stack. Each Environment has Configuration that defines the specific *implementation* of infrastructure supporting your code. For example, your Dev environment could be a small EC2 box with docker-compose, and Production could run in a dedicated Kubernetes cluster with multi-AZ RDS. Services and Resources can be configured independently for each environment.
+- **Environments** - isolated independent copies of your entire stack. Each Environment has Configuration that defines the specific _implementation_ of infrastructure supporting your code. For example, your Dev environment could be a small EC2 box with docker-compose, and Production could run in a dedicated Kubernetes cluster with multi-AZ RDS. Services and Resources can be configured independently for each environment.
 
 - **Targets** - generic templates that generate specific implementation (Terraform) for each environment. Each Target can support a wide variety of stacks. More in [Understanding Targets](#understanding-targets)
 
@@ -30,15 +30,16 @@ Knowing the structure of your stack and the state of each environment allows Dig
 
 ## Understanding Targets
 
-Digger Targets are the templates for the infrastructure that Digger creates and manages in your AWS account. We had to come up with a new name because Terraform files are commonly referred to as "templates" - whereas Digger Targets _produce_ Terraform, so they are "temmplates of templates" in a way.
+Digger Targets are the templates for the infrastructure that Digger creates and manages in your AWS account. We had to come up with a new name because Terraform files are commonly referred to as "templates" - whereas Digger Targets _produce_ Terraform, so they are "templates of templates" in a way.
 
 This extra layer is needed because Digger cleanly separates infrastructure implementation from configuration. A Target does not describe your infrastructure precisely - instead, it describes a particular architecture that can produce many possible variations for a wide variety of stacks, depending on configuration.
 
 ```
 Stack State + Target + Environment Config => Terraform for a particular environment
 ```
+
 - **Stack State** is the logical structure of your stack - apps, services, databases etc.
-- **Environment Config** is configuration specific to a particular environment. 
+- **Environment Config** is configuration specific to a particular environment.
 - **Target** takes Stack State and Environment Config and produces Terraform
 
 :::tip

--- a/docs/quickstart-static.md
+++ b/docs/quickstart-static.md
@@ -1,5 +1,9 @@
 # Run a single-page app
+
 ## React
+
 ## Vue
+
 ## Angular
+
 ## Static website

--- a/docs/reference-cli.md
+++ b/docs/reference-cli.md
@@ -1,5 +1,6 @@
 # CLI reference
-Did you know that our CLI is open source? You can contribute [bug reports and feature requests on github](https://github.com/diggerhq/cli)
+
+Did you know that our CLI is open source? You can contribute [bug reports and feature requests on GitHub](https://github.com/diggerhq/cli)
 
 ::: warning
 API is subject to change in future versions of the CLI.
@@ -10,104 +11,105 @@ Almost all commands are run in the context of digger.yml. This is used to identi
 :::
 
 ## dg auth
+
 - Requires Auth: no
 - Context: N/A
 
 Authenticate and retrieve Digger token. This command open browser for authentication.
 
 ## dg project init
+
 - Requires Auth: yes
 - Context: Project root (initialises digger.yml)
 
 Initialize a project by name (creates entry in backend). Also creates initial digger.yml file.
 
-
-| Option                      | Description                                                                    | Required          |
-| --------------------------- | ------------------------------------------------------------------------------ | ----------------- |
-| `--name`                    | The project name. if not entered you will be asked to enter it as input.       | No                |
-
+| Option   | Description                                                              | Required |
+| -------- | ------------------------------------------------------------------------ | -------- |
+| `--name` | The project name. if not entered you will be asked to enter it as input. | No       |
 
 ## dg sync
+
 - Requires Auth: yes
 - Context: digger.yml
 
 Sync services from digger.yml to backend.
 
 ## dg service add
+
 - Requires Auth: yes
 - Context: digger.yml
 
 Helper to add a service to digger.yml. Will ask you for the path to the service and then guess the details of this service in digger.yml.
 
 ## dg env build env_name
+
 - Requires Auth: yes
 - Context: digger.yml
 
-
-| Option                      | Description                                                                                                      | Required          |
-| --------------------------- | ---------------------------------------------------------------------------------------------------------------- | ----------------- |
-| `--service`                 | The name of the service. <br><br>This needs to be present in the digger.yml `services` section                   | No                |
-| `--tag`                     | The tag of the image to be built - default to 'latest'                                                           | No                |
-| `--context`                 | For docker container builds. The context of the docker build.<br><br> Defaults to the location of the Dockerfile | No                |
-
+| Option      | Description                                                                                                      | Required |
+| ----------- | ---------------------------------------------------------------------------------------------------------------- | -------- |
+| `--service` | The name of the service. <br><br>This needs to be present in the digger.yml `services` section                   | No       |
+| `--tag`     | The tag of the image to be built - default to 'latest'                                                           | No       |
+| `--context` | For docker container builds. The context of the docker build.<br><br> Defaults to the location of the Dockerfile | No       |
 
 ## dg env push env_name
+
 - Requires Auth: yes
 - Context: digger.yml
 
-| Option                      | Description                                                                                                      | Required          |
-| --------------------------- | ---------------------------------------------------------------------------------------------------------------- | ----------------- |
-| `--service`                 | The name of the service. <br><br>This needs to be present in the digger.yml `services` section                   | No                |
-| `--tag`                     | The tag of the image to be built - default to 'latest'                                                           | No                |
-| `--aws-key`                 | The AWS key of the account that contains the ECR respository                                                     | No                |
-| `--aws-secret`              | The AWS secret of the account with ECR repository                                                                | No                |
-
+| Option         | Description                                                                                    | Required |
+| -------------- | ---------------------------------------------------------------------------------------------- | -------- |
+| `--service`    | The name of the service. <br><br>This needs to be present in the digger.yml `services` section | No       |
+| `--tag`        | The tag of the image to be built - default to 'latest'                                         | No       |
+| `--aws-key`    | The AWS key of the account that contains the ECR respository                                   | No       |
+| `--aws-secret` | The AWS secret of the account with ECR repository                                              | No       |
 
 ## dg env release env_name
+
 - Requires Auth: yes
 - Context: digger.yml
 
-| Option                      | Description                                                                                                      | Required          |
-| --------------------------- | ---------------------------------------------------------------------------------------------------------------- | ----------------- |
-| `--service`                 | The name of the service. <br><br>This needs to be present in the digger.yml `services` section                   | No                |
-| `--tag`                     | The tag of the image to be built - default to 'latest'                                                           | No                |
-| `--aws-key`                 | The AWS key of the account that contains the ECR respository                                                     | No                |
-| `--aws-secret`              | The AWS secret of the account with ECR repository                                                                | No                |
-
+| Option         | Description                                                                                    | Required |
+| -------------- | ---------------------------------------------------------------------------------------------- | -------- |
+| `--service`    | The name of the service. <br><br>This needs to be present in the digger.yml `services` section | No       |
+| `--tag`        | The tag of the image to be built - default to 'latest'                                         | No       |
+| `--aws-key`    | The AWS key of the account that contains the ECR respository                                   | No       |
+| `--aws-secret` | The AWS secret of the account with ECR repository                                              | No       |
 
 ## dg env create env_name
+
 - Requires Auth: yes
 - Context: digger.yml
 
-
-| Option                      | Description                                                                                                              | Required          |
-| --------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ----------------- |
-| `--target`                  | The repository which contains terraform template to apply. This argument should be of the form 'orgname/reponame@branch' | No                |
-| `--region`                  | The AWS region to create the infrastructure in                                                                           | No                |
-| `--config`                  | a list of key=value pair to use for environment config options. You can specify multiple key=value pairs inline          | No                |
-| `--aws-key`                 | The AWS key of the account                                                                                               | No                |
-| `--aws-secret`              | The AWS secret of the account                                                                                            | No                |
-
+| Option         | Description                                                                                                              | Required |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------ | -------- |
+| `--target`     | The repository which contains terraform template to apply. This argument should be of the form 'orgname/reponame@branch' | No       |
+| `--region`     | The AWS region to create the infrastructure in                                                                           | No       |
+| `--config`     | a list of key=value pair to use for environment config options. You can specify multiple key=value pairs inline          | No       |
+| `--aws-key`    | The AWS key of the account                                                                                               | No       |
+| `--aws-secret` | The AWS secret of the account                                                                                            | No       |
 
 ## dg env plan env_name
+
 - Requires Auth: yes
 - Context: digger.yml
 
 Outputs the list of planned resource that will be created for this environment. It is highly recommended to run this command before each apply.
 
-
 ## dg env apply env_name
+
 - Requires Auth: yes
 - Context: digger.yml
 
 Applies the changes of the environment. Note: It is recommend to run a `dg plan` before `dg apply`.
 
-| Option                      | Description                                                                    | Required          |
-| --------------------------- | ------------------------------------------------------------------------------ | ----------------- |
-| `--verboose`                | Stream the terraform output while running the command                          | No                |
-
+| Option       | Description                                           | Required |
+| ------------ | ----------------------------------------------------- | -------- |
+| `--verboose` | Stream the terraform output while running the command | No       |
 
 ## dg env update env_name
+
 - Requires Auth: yes
 - Context: digger.yml
 
@@ -121,20 +123,22 @@ Update the settings of an environment. Currently supports updating of:
 Usually will need to be followed by an `env apply` command
 
 ## dg env destroy env_name
+
 - Requires Auth: yes
 - Context: digger.yml
 
 Destroy an environment (Warning: will destroy all infrastructure create)
 
 ## dg env describe env_name
+
 - Requires Auth: yes
 - Context: digger.yml
 
 Print all the details of an existing environment including all terraform outputs (Warning verbose output).
 
 ## dg env list
+
 - Requires Auth: yes
 - Context: digger.yml
 
 List all the existing environments, along with some details about them.
-

--- a/docs/reference-yaml.md
+++ b/docs/reference-yaml.md
@@ -8,32 +8,32 @@ The structure of this digger.yml file is subject to change in future version of 
 
 There are two main top-level parts of digger.yml, `project` and `services`. The project section contains metadata about the active project. The services section contains a list of service metadata. In the snippet bellow we capture the main elements of a typical digger.yml along with comments to explain each field
 
-```
+```yaml
 project:
   name: projectname
 services:
   svc:
     service_name: svc1 # The service name, in most cases it will be the same as the toplevel key
     path: . # where the service lives, a path relative to the root repo
-    env_files: [] # currently unused, in future will be used to point .env files 
+    env_files: [] # currently unused, in future will be used to point .env files
     publicly_accissible: true # whether this is an external or internal service
     service_type: container # the type of the service
     container_port: 5000 # the port which the container listens in. NOTE this is the container port NOT the port exposed to the host
     health_check: /api/v1/hello # An unauthenticated path, required by loadbalancers
     dockerfile: ./Dockerfile # path to dockerfile relative to root repository
     needs: [] # needs specifies
-    dependencies: {} # currently unused, in the future will point to other services which this service depends on 
+    dependencies: {} # currently unused, in the future will point to other services which this service depends on
 ```
 
 ## Defining Resource dependencies
 
-Resources are specified under every service. here is an example where svcA needs one resource and svcB needs another database resource. Names in the spec have to be unique. 
+Resources are specified under every service. here is an example where svcA needs one resource and svcB needs another database resource. Names in the spec have to be unique.
 
-```
+```yaml
 services:
     svcA:
-        service_name: 
-        service_path: 
+        service_name:
+        service_path:
         needs:
         - database:
             name: x
@@ -52,34 +52,32 @@ services:
 
 Note that two services can optionally share the same resource. This will help reduce infrastructure creation time and the costs incurred. To share resources we can reference other resources using a dollar sign:
 
-
-```
+```yaml
 services:
-    svcA:
-        service_name: serviceA
-        service_path: ./
-        # ...
-        needs:
-        - database:
-            name: x1
-            engine: postgres
-            size: 10gb
+  svcA:
+    service_name: serviceA
+    service_path: ./
+    # ...
+    needs:
+      - database:
+          name: x1
+          engine: postgres
+          size: 10gb
 
-    svcB:
-        service_name: seviceB
-        service_path: ./serviceB
-        needs:
-        - database:
-            ref: $x1 #<-- database x1 is now accessible by svcB
+  svcB:
+    service_name: seviceB
+    service_path: ./serviceB
+    needs:
+      - database:
+          ref: $x1 #<-- database x1 is now accessible by svcB
 ```
 
 ## Using existing resources
 
 If you want to use existing resources and make them accessible by a service you can do that by specifying this in a top block called existing_resources. This is on a per-environment basis using {environment}.{resource_name} as the key and an arn value
 
-```
+```yaml
 existing_resources:
-    - production.mydb: arn_string
-    - staging: arn_string
-
+  - production.mydb: arn_string
+  - staging: arn_string
 ```


### PR DESCRIPTION
based on markdown lint, but there are still some warnings like `header-increment` since i don't want to change vuepress sidebar structure; and some custom code blocks

note: language specifier based on syntax highlighting, so I added `bash` to Terraform code block just because it can colorize the syntax